### PR TITLE
Fix issue with checkpoint saving (save-dir argument not respected)

### DIFF
--- a/train.py
+++ b/train.py
@@ -45,7 +45,7 @@ def main():
     training_wrapper = create_training_wrapper_from_config(model_config, model)
 
     exc_callback = ExceptionCallback()
-    ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, save_top_k=-1)
+    ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, save_top_k=-1, dirpath=args.save_dir)
     save_model_config_callback = ModelConfigEmbedderCallback(model_config)
 
     demo_callback = create_demo_callback_from_config(model_config, demo_dl=train_dl)


### PR DESCRIPTION
This PR passes the training script's save-dir argument to the ModelCheckpoint constructor, which fixes the issue of not being able to specify where to save the training checkpoints.