### PR TITLE
fix: call model.quantizer with latents in PretrainedDACPretransform

### DIFF
--- a/stable_audio_tools/models/pretransforms.py
+++ b/stable_audio_tools/models/pretransforms.py
@@ -106,7 +106,7 @@ class PretrainedDACPretransform(Pretransform):
         if self.quantize_on_decode:
             output = latents
         else:
-            z, _, latents, _, _ = self.model.quantizer(z, n_quantizers=self.model.n_codebooks)
+            z, _, _, _, _ = self.model.quantizer(latents, n_quantizers=self.model.n_codebooks)
             output = z
         
         if self.scale != 1.0:


### PR DESCRIPTION
If `quantize_on_decode = False` this code will break since `z` is not defined. We want to quantize the `latents` to get `z`.