### PR TITLE
Fix upper-bound calculation for cropping

### DIFF
--- a/stable_audio_tools/data/utils.py
+++ b/stable_audio_tools/data/utils.py
@@ -37,7 +37,7 @@ class PadCrop_Normalized_T(nn.Module):
         
         offset = 0
         if(self.randomize and n_samples > self.n_samples):
-            offset = random.randint(0, upper_bound + 1)
+            offset = random.randint(0, upper_bound)
 
         t_start = offset / (upper_bound + self.n_samples)
         t_end = (offset + self.n_samples) / (upper_bound + self.n_samples)


### PR DESCRIPTION
I ran into `RuntimeError`s after I unwrapped the `__getitem__` logic in the `SampleDataset` from the `try except` due to what seemed to me overshooting the `offset` by `1`. It happens really rarely, because its only a problem when `offset = upper_bound + 1`. The problem is that `random.randint(n, m)` returns values including `n` and `m`.

Thank you for the nice repo btw!