### PR TITLE
fix "Couldn't load file" spam

### DIFF
--- a/stable_audio_tools/data/dataset.py
+++ b/stable_audio_tools/data/dataset.py
@@ -142,6 +142,8 @@ class SampleDataset(torch.utils.data.Dataset):
 
         self.custom_metadata_fn = custom_metadata_fn
 
+        torchaudio.set_audio_backend('soundfile')
+
     def load_file(self, filename):
         ext = filename.split(".")[-1]
 


### PR DESCRIPTION
several times now I've had my environment crash, and when starting a training run in the new environment it will spam "Couldn't load file: [path]" and lag the console until it dies. Something in the broken environment is forcing torchaudio to load the sox backend, which in my case doesn't exist, causing this error. Adding this line is significantly easier than installing sox, and you won't get any more error spam. 

note: everything *should* work fine by default- this only does anything when the environment crashes and you restart and get endless file load errors.