### PR TITLE
Fixing bugs in audio saving of AutoEncoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Logs
+wandb/
+runs/

--- a/stable_audio_tools/configs/model_configs/autoencoders/dac_2048_32_vae.json
+++ b/stable_audio_tools/configs/model_configs/autoencoders/dac_2048_32_vae.json
@@ -65,7 +65,8 @@
             }
         },
         "demo": {
-            "demo_every": 2000
+            "demo_every": 2000,
+            "max_num_sample": 4
         }
     }
 }

--- a/stable_audio_tools/configs/model_configs/autoencoders/encodec_musicgen_rvq.json
+++ b/stable_audio_tools/configs/model_configs/autoencoders/encodec_musicgen_rvq.json
@@ -82,7 +82,8 @@
             }
         },
         "demo": {
-            "demo_every": 2000
+            "demo_every": 2000,
+            "max_num_sample": 4
         }
     }
 }

--- a/stable_audio_tools/configs/model_configs/autoencoders/stable_audio_1_0_vae.json
+++ b/stable_audio_tools/configs/model_configs/autoencoders/stable_audio_1_0_vae.json
@@ -105,7 +105,8 @@
             }
         },
         "demo": {
-            "demo_every": 2000
+            "demo_every": 2000,
+            "max_num_sample": 4
         }
     }
 }

--- a/stable_audio_tools/configs/model_configs/autoencoders/stable_audio_2_0_vae.json
+++ b/stable_audio_tools/configs/model_configs/autoencoders/stable_audio_2_0_vae.json
@@ -116,7 +116,8 @@
             }
         },
         "demo": {
-            "demo_every": 2000
+            "demo_every": 2000,
+            "max_num_sample": 4
         }
     }
 }

--- a/stable_audio_tools/training/factory.py
+++ b/stable_audio_tools/training/factory.py
@@ -2,6 +2,7 @@ import torch
 from torch.nn import Parameter
 from ..models.factory import create_model_from_config
 
+
 def create_training_wrapper_from_config(model_config, model):
     model_type = model_config.get('model_type', None)
     assert model_type is not None, 'model_type must be specified in model config'
@@ -16,7 +17,7 @@ def create_training_wrapper_from_config(model_config, model):
 
         if training_config.get("use_ema", False):
             ema_copy = create_model_from_config(model_config)
-            ema_copy = create_model_from_config(model_config) # I don't know why this needs to be called twice but it broke when I called it once
+            ema_copy = create_model_from_config(model_config)  # I don't know why this needs to be called twice but it broke when I called it once
             # Copy each weight to the ema copy
             for name, param in model.state_dict().items():
                 if isinstance(param, Parameter):
@@ -40,9 +41,9 @@ def create_training_wrapper_from_config(model_config, model):
                 raise ValueError("teacher_model_ckpt must be specified if teacher_model is specified")
 
         return AutoencoderTrainingWrapper(
-            model, 
+            model,
             lr=training_config["learning_rate"],
-            warmup_steps=training_config.get("warmup_steps", 0), 
+            warmup_steps=training_config.get("warmup_steps", 0),
             encoder_freeze_on_warmup=training_config.get("encoder_freeze_on_warmup", False),
             sample_rate=model_config["sample_rate"],
             loss_config=training_config.get("loss_configs", None),
@@ -56,18 +57,18 @@ def create_training_wrapper_from_config(model_config, model):
     elif model_type == 'diffusion_uncond':
         from .diffusion import DiffusionUncondTrainingWrapper
         return DiffusionUncondTrainingWrapper(
-            model, 
+            model,
             lr=training_config["learning_rate"],
         )
     elif model_type == 'diffusion_cond':
         from .diffusion import DiffusionCondTrainingWrapper
         return DiffusionCondTrainingWrapper(
-            model, 
+            model,
             lr=training_config.get("learning_rate", None),
             causal_dropout=training_config.get("causal_dropout", 0.0),
             mask_padding=training_config.get("mask_padding", False),
             mask_padding_dropout=training_config.get("mask_padding_dropout", 0.0),
-            use_ema = training_config.get("use_ema", True),
+            use_ema=training_config.get("use_ema", True),
             log_loss_info=training_config.get("log_loss_info", False),
             optimizer_configs=training_config.get("optimizer_configs", None),
             use_reconstruction_loss=training_config.get("use_reconstruction_loss", False),
@@ -77,7 +78,7 @@ def create_training_wrapper_from_config(model_config, model):
         from ..models.diffusion_prior import PriorType
 
         ema_copy = create_model_from_config(model_config)
-        
+
         # Copy each weight to the ema copy
         for name, param in model.state_dict().items():
             if isinstance(param, Parameter):
@@ -95,7 +96,7 @@ def create_training_wrapper_from_config(model_config, model):
             raise ValueError(f"Unknown prior type: {prior_type}")
 
         return DiffusionPriorTrainingWrapper(
-            model, 
+            model,
             lr=training_config["learning_rate"],
             ema_copy=ema_copy,
             prior_type=prior_type_enum,
@@ -105,14 +106,14 @@ def create_training_wrapper_from_config(model_config, model):
     elif model_type == 'diffusion_cond_inpaint':
         from .diffusion import DiffusionCondInpaintTrainingWrapper
         return DiffusionCondInpaintTrainingWrapper(
-            model, 
+            model,
             lr=training_config["learning_rate"]
         )
     elif model_type == 'diffusion_autoencoder':
         from .diffusion import DiffusionAutoencoderTrainingWrapper
 
         ema_copy = create_model_from_config(model_config)
-        
+
         # Copy each weight to the ema copy
         for name, param in model.state_dict().items():
             if isinstance(param, Parameter):
@@ -164,6 +165,7 @@ def create_training_wrapper_from_config(model_config, model):
     else:
         raise NotImplementedError(f'Unknown model type: {model_type}')
 
+
 def create_demo_callback_from_config(model_config, **kwargs):
     model_type = model_config.get('model_type', None)
     assert model_type is not None, 'model_type must be specified in model config'
@@ -176,22 +178,23 @@ def create_demo_callback_from_config(model_config, **kwargs):
     if model_type == 'autoencoder':
         from .autoencoders import AutoencoderDemoCallback
         return AutoencoderDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
-            sample_size=model_config["sample_size"], 
+            demo_every=demo_config.get("demo_every", 2000),
+            max_num_sample=demo_config.get("max_num_sample", 4),
+            sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
             **kwargs
         )
     elif model_type == 'diffusion_uncond':
         from .diffusion import DiffusionUncondDemoCallback
         return DiffusionUncondDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
-            demo_steps=demo_config.get("demo_steps", 250), 
+            demo_every=demo_config.get("demo_every", 2000),
+            demo_steps=demo_config.get("demo_steps", 250),
             sample_rate=model_config["sample_rate"]
         )
     elif model_type == "diffusion_autoencoder":
         from .diffusion import DiffusionAutoencoderDemoCallback
         return DiffusionAutoencoderDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
+            demo_every=demo_config.get("demo_every", 2000),
             demo_steps=demo_config.get("demo_steps", 250),
             sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
@@ -200,7 +203,7 @@ def create_demo_callback_from_config(model_config, **kwargs):
     elif model_type == "diffusion_prior":
         from .diffusion import DiffusionPriorDemoCallback
         return DiffusionPriorDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
+            demo_every=demo_config.get("demo_every", 2000),
             demo_steps=demo_config.get("demo_steps", 250),
             sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
@@ -210,10 +213,10 @@ def create_demo_callback_from_config(model_config, **kwargs):
         from .diffusion import DiffusionCondDemoCallback
 
         return DiffusionCondDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
+            demo_every=demo_config.get("demo_every", 2000),
             sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
-            demo_steps=demo_config.get("demo_steps", 250), 
+            demo_steps=demo_config.get("demo_steps", 250),
             num_demos=demo_config["num_demos"],
             demo_cfg_scales=demo_config["demo_cfg_scales"],
             demo_conditioning=demo_config.get("demo_cond", {}),
@@ -224,7 +227,7 @@ def create_demo_callback_from_config(model_config, **kwargs):
         from .diffusion import DiffusionCondInpaintDemoCallback
 
         return DiffusionCondInpaintDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
+            demo_every=demo_config.get("demo_every", 2000),
             sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
             demo_steps=demo_config.get("demo_steps", 250),
@@ -235,19 +238,19 @@ def create_demo_callback_from_config(model_config, **kwargs):
         from .musicgen import MusicGenDemoCallback
 
         return MusicGenDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
+            demo_every=demo_config.get("demo_every", 2000),
             sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
             demo_cfg_scales=demo_config["demo_cfg_scales"],
             demo_conditioning=demo_config["demo_cond"],
             **kwargs
         )
-    
+
     elif model_type == "lm":
         from .lm import AudioLanguageModelDemoCallback
 
         return AudioLanguageModelDemoCallback(
-            demo_every=demo_config.get("demo_every", 2000), 
+            demo_every=demo_config.get("demo_every", 2000),
             sample_size=model_config["sample_size"],
             sample_rate=model_config["sample_rate"],
             demo_cfg_scales=demo_config.get("demo_cfg_scales", [1]),

--- a/train.py
+++ b/train.py
@@ -11,9 +11,11 @@ from stable_audio_tools.models.utils import load_ckpt_state_dict, remove_weight_
 from stable_audio_tools.training import create_training_wrapper_from_config, create_demo_callback_from_config
 from stable_audio_tools.training.utils import copy_state_dict
 
+
 class ExceptionCallback(pl.Callback):
     def on_exception(self, trainer, module, err):
         print(f'{type(err).__name__}: {err}')
+
 
 class ModelConfigEmbedderCallback(pl.Callback):
     def __init__(self, model_config):
@@ -21,6 +23,7 @@ class ModelConfigEmbedderCallback(pl.Callback):
 
     def on_save_checkpoint(self, trainer, pl_module, checkpoint):
         checkpoint["model_config"] = self.model_config
+
 
 def main():
 
@@ -35,7 +38,7 @@ def main():
     random.seed(seed)
     torch.manual_seed(seed)
 
-    #Get JSON config from args.model_config
+    # Get JSON config from args.model_config
     with open(args.model_config) as f:
         model_config = json.load(f)
 
@@ -43,8 +46,8 @@ def main():
         dataset_config = json.load(f)
 
     train_dl = create_dataloader_from_config(
-        dataset_config, 
-        batch_size=args.batch_size, 
+        dataset_config,
+        batch_size=args.batch_size,
         num_workers=args.num_workers,
         sample_rate=model_config["sample_rate"],
         sample_size=model_config["sample_size"],
@@ -55,13 +58,13 @@ def main():
 
     if args.pretrained_ckpt_path:
         copy_state_dict(model, load_ckpt_state_dict(args.pretrained_ckpt_path))
-    
+
     if args.remove_pretransform_weight_norm == "pre_load":
         remove_weight_norm_from_model(model.pretransform)
 
     if args.pretransform_ckpt_path:
         model.pretransform.load_state_dict(load_ckpt_state_dict(args.pretransform_ckpt_path))
-    
+
     # Remove weight_norm from the pretransform if specified
     if args.remove_pretransform_weight_norm == "post_load":
         remove_weight_norm_from_model(model.pretransform)
@@ -72,10 +75,12 @@ def main():
     wandb_logger.watch(training_wrapper)
 
     exc_callback = ExceptionCallback()
-    
+
     if args.save_dir and isinstance(wandb_logger.experiment.id, str):
-        checkpoint_dir = os.path.join(args.save_dir, wandb_logger.experiment.project, wandb_logger.experiment.id, "checkpoints") 
+        save_dir = os.path.join(args.save_dir, wandb_logger.experiment.project, wandb_logger.experiment.id)
+        checkpoint_dir = os.path.join(save_dir, "checkpoints")
     else:
+        save_dir = None
         checkpoint_dir = None
 
     ckpt_callback = pl.callbacks.ModelCheckpoint(every_n_train_steps=args.checkpoint_every, dirpath=checkpoint_dir, save_top_k=-1)
@@ -83,46 +88,47 @@ def main():
 
     demo_callback = create_demo_callback_from_config(model_config, demo_dl=train_dl)
 
-    #Combine args and config dicts
+    # Combine args and config dicts
     args_dict = vars(args)
     args_dict.update({"model_config": model_config})
     args_dict.update({"dataset_config": dataset_config})
     push_wandb_config(wandb_logger, args_dict)
 
-    #Set multi-GPU strategy if specified
+    # Set multi-GPU strategy if specified
     if args.strategy:
         if args.strategy == "deepspeed":
             from pytorch_lightning.strategies import DeepSpeedStrategy
-            strategy = DeepSpeedStrategy(stage=2, 
-                                        contiguous_gradients=True, 
-                                        overlap_comm=True, 
-                                        reduce_scatter=True, 
-                                        reduce_bucket_size=5e8, 
-                                        allgather_bucket_size=5e8,
-                                        load_full_weights=True
-                                        )
+            strategy = DeepSpeedStrategy(stage=2,
+                                         contiguous_gradients=True,
+                                         overlap_comm=True,
+                                         reduce_scatter=True,
+                                         reduce_bucket_size=5e8,
+                                         allgather_bucket_size=5e8,
+                                         load_full_weights=True
+                                         )
         else:
             strategy = args.strategy
     else:
-        strategy = 'ddp_find_unused_parameters_true' if args.num_gpus > 1 else "auto" 
+        strategy = 'ddp_find_unused_parameters_true' if args.num_gpus > 1 else "auto"
 
     trainer = pl.Trainer(
         devices=args.num_gpus,
         accelerator="gpu",
-        num_nodes = args.num_nodes,
+        num_nodes=args.num_nodes,
         strategy=strategy,
         precision=args.precision,
-        accumulate_grad_batches=args.accum_batches, 
+        accumulate_grad_batches=args.accum_batches,
         callbacks=[ckpt_callback, demo_callback, exc_callback, save_model_config_callback],
         logger=wandb_logger,
         log_every_n_steps=1,
         max_epochs=10000000,
-        default_root_dir=args.save_dir,
+        default_root_dir=save_dir,
         gradient_clip_val=args.gradient_clip_val,
-        reload_dataloaders_every_n_epochs = 0
+        reload_dataloaders_every_n_epochs=0
     )
 
     trainer.fit(training_wrapper, train_dl, ckpt_path=args.ckpt_path if args.ckpt_path else None)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixed unexpected behaviors in audio sample saving of AutoEncoder.

1. Saved audio was collapsed due to wrong 'rearrange' procedure. -> fixed
2. Default direcotry of audio saving was a root working direcotry (no direcotry is set during audio sample saving.)
I prepare a 'samples' directory in the parent directory of the 'checkpoints' directory. 