### PR TITLE
[update] Auto trim the audio file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'einops-exts==0.0.4',
         'ema-pytorch==0.2.3',
         'encodec==0.1.1',
+        'ffmpeg-python==0.2.0',
         'gradio>=3.42.0',
         'huggingface_hub',
         'importlib-resources==5.12.0',


### PR DESCRIPTION
* Auto trims the audio file based on the seconds totals
* Seconds total limited to 1 second minimum and 47 maximum
* FFMPEG for Python added as a requirement in setup.py
* `Import os` also added to imports to handle file removal of output file if older one exists. (Prevents future conflicts)