### PR TITLE
Add GitHub Actions workflow for testing dependency installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          cache: pip
+
+      - name: Install libsndfile1
+        run: sudo apt-get install libsndfile1
+
+      - name: Install dependencies
+        run: pip install .
+
+      - name: Check training script
+        run: python train.py --help


### PR DESCRIPTION
`pip install` hell is real and it's nice to see that things work on a fresh machine. Here's a suggestion of a small GitHub Actions workflow for testing that the training script doesn't have any import errors after installing the `setup.py`.
