### PR TITLE
Add support for CPU and MPS across the tools in this repo

### DIFF
--- a/stable_audio_tools/inference/generation.py
+++ b/stable_audio_tools/inference/generation.py
@@ -8,13 +8,20 @@ from .utils import prepare_audio
 from .sampling import sample, sample_k, sample_rf
 from ..data.utils import PadCrop
 
+if torch.cuda.is_available():
+    device = torch.device('cuda')
+elif torch.backends.mps.is_available():
+    device = torch.device('mps')
+else:
+    device = torch.device('cpu')
+
 def generate_diffusion_uncond(
         model,
         steps: int = 250,
         batch_size: int = 1,
         sample_size: int = 2097152,
         seed: int = -1,
-        device: str = "cuda",
+        device: str = device.type,
         init_audio: tp.Optional[tp.Tuple[int, torch.Tensor]] = None,
         init_noise_level: float = 1.0,
         return_latents = False,

--- a/stable_audio_tools/interface/gradio.py
+++ b/stable_audio_tools/interface/gradio.py
@@ -24,7 +24,14 @@ model = None
 sample_rate = 32000
 sample_size = 1920000
 
-def load_model(model_config=None, model_ckpt_path=None, pretrained_name=None, pretransform_ckpt_path=None, device="cuda", model_half=False):
+if torch.cuda.is_available():
+    device = torch.device('cuda')
+elif torch.backends.mps.is_available():
+    device = torch.device('mps')
+else:
+    device = torch.device('cpu')
+
+def load_model(model_config=None, model_ckpt_path=None, pretrained_name=None, pretransform_ckpt_path=None, device=device, model_half=False):
     global model, sample_rate, sample_size
     
     if pretrained_name is not None:


### PR DESCRIPTION
Hi, thanks for the lovely toolbox. This PR adds conditional selection of the device to use (CUDA, MPS, and CPU) and specifies it explicitly where it was previously unspecified.

Additionally, it updates the deprecated `torch.cuda.amp.autocast` to `torch.amp.autocast`, as recommended by the documentation.

This PR enables running inference (and training, although it’s unlikely anyone would want to) on MacBooks with Apple Silicon chips.

P.S. Please let me know if there is anything that needs to be changed for this contribution to be accepted. If it won’t be accepted, that’s fine too- just let me know, and I will continue working on this project in my own fork.
