### PR TITLE
Add support for 24GB VRAM fine tuning via 8bit optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ The following properties are defined in the top level of the model configuration
 - `training`
   - The training configuration for the model, varies based on `model_type`. Provides parameters for training as well as demos.
 
+
+### Optimizer config
+The model config file defines all of the information needed to load a model for training or inference. It also contains the training configuration needed to fine-tune a model or train from scratch.
+
+- `backend`
+  - The type of optimizer library being used, currently limited to one of `"bnb", "default"`.
+- `type`
+  - Optimizer name to use. If using bnb, enabled the use of `"AdamW8bit"` and other 8bit optimizers.
+
+
 ## Dataset config
 `stable-audio-tools` currently supports two kinds of data sources: local directories of audio files, and WebDataset datasets stored in Amazon S3. More information can be found in [the dataset config documentation](docs/datasets.md)
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following properties are defined in the top level of the model configuration
 
 
 ### Optimizer config
-The model config file defines all of the information needed to load a model for training or inference. It also contains the training configuration needed to fine-tune a model or train from scratch.
+The optimizer config file allows for use of different optimizer implementations, including those that allow for fine tuning with 24GB VRAM.
 
 - `backend`
   - The type of optimizer library being used, currently limited to one of `"bnb", "default"`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following properties are defined in the top level of the model configuration
 
 
 ### Optimizer config
-The optimizer config file allows for use of different optimizer implementations, including those that allow for fine tuning with 24GB VRAM.
+The optimizer config, inside of the training subsection of the model config, allows for use of different optimizer implementations, including those that allow for fine tuning with 24GB VRAM.
 
 - `backend`
   - The type of optimizer library being used, currently limited to one of `"bnb", "default"`.

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'aeiou==0.0.20',
         'alias-free-torch==0.0.6',
         'auraloss==0.4.0',
+        'bitsandbytes==0.35.0',
         'descript-audio-codec==1.0.0',
         'einops==0.7.0',
         'einops-exts==0.0.4',

--- a/stable_audio_tools/training/utils.py
+++ b/stable_audio_tools/training/utils.py
@@ -84,13 +84,20 @@ def create_optimizer_from_config(optimizer_config, parameters):
     """
 
     optimizer_type = optimizer_config["type"]
+    optimizer_backend = optimizer_config.get("backend", "")
 
-    if optimizer_type == "FusedAdam":
-        from deepspeed.ops.adam import FusedAdam
-        optimizer = FusedAdam(parameters, **optimizer_config["config"])
-    else:
-        optimizer_fn = getattr(torch.optim, optimizer_type)
+    if optimizer_backend == "bnb":
+        import bitsandbytes as bnb
+        optimizer_fn = getattr(bnb.optim, optimizer_type)
         optimizer = optimizer_fn(parameters, **optimizer_config["config"])
+    else:
+        if optimizer_type == "FusedAdam":
+            from deepspeed.ops.adam import FusedAdam
+            optimizer = FusedAdam(parameters, **optimizer_config["config"])
+        else:
+            optimizer_fn = getattr(torch.optim, optimizer_type)
+            optimizer = optimizer_fn(parameters, **optimizer_config["config"])
+            
     return optimizer
 
 def create_scheduler_from_config(scheduler_config, optimizer):


### PR DESCRIPTION
Caveats: Open to feedback on configuration - wasn't entirely clear how to separate it, but made it generic enough to pull in any optimizer from bnb.

**Summary of changes**
- Introduces dependency on bitsandbytes
- Introduces an optimizer flag to configure bnb usage
- Documentation

**Tests done**
5k test wav dataset, stock model config, and stock pretrained model:
  | Name          | Type                             | Params
-------------------------------------------------------------------
0 | diffusion     | ConditionedDiffusionModelWrapper | 1.2 B
1 | diffusion_ema | EMA                              | 1.1 B
2 | losses        | MultiLoss                        | 0
-------------------------------------------------------------------
1.1 B     Trainable params
1.2 B     Non-trainable params
2.3 B     Total params
9,080.665 Total estimated model params size (MB)

With VRAM usage observed:
 Device 0 [NVIDIA GeForce RTX 3090] PCIe GEN 4@16x RX: 47.85 MiB/s TX: 7.812 MiB/s
 GPU 1635MHz MEM 9501MHz TEMP  77°C FAN  97% POW 315 / 350 W
 GPU[|||||||||||||||||||||||||||||||100%] MEM[||||||||||||||||||22.367Gi/24.000Gi]

