### PR TITLE
Raise errors if sampler_type unhandled

### DIFF
--- a/stable_audio_tools/inference/sampling.py
+++ b/stable_audio_tools/inference/sampling.py
@@ -384,6 +384,8 @@ def sample_k(
             return K.sampling.sample_dpmpp_2m_sde(denoiser, x, sigmas, disable=False, callback=callback, extra_args=extra_args)
         elif sampler_type == "dpmpp-3m-sde":
             return K.sampling.sample_dpmpp_3m_sde(denoiser, x, sigmas, disable=False, callback=callback, extra_args=extra_args)
+        else:
+            raise ValueError(f"Unknown sampler_type: {sampler_type}")
     elif is_v_diff:
 
         if sigma_max > 1: # sigma_max should be between 0 and 1
@@ -455,3 +457,5 @@ def sample_rf(
         return sample_flow_dpmpp(model_fn, x, sigmas=t, sigma_max=sigma_max, callback=callback, **extra_args)
     elif sampler_type == "pingpong":
         return sample_flow_pingpong(model_fn, x, sigmas=t, sigma_max=sigma_max, callback=callback, **extra_args)
+    else:
+        raise ValueError(f"Unknown sampler_type: {sampler_type}")


### PR DESCRIPTION
Noticed that if rectified flow is used but sampler_type isn't updated correctly, generate_diffusion_cond will crash as `sampled` will be `None`. As that subsequent error is hard to grok and debug, it would be easier to raise relevant errors inside the samplers.