### PR TITLE
Update docs on working with pre encoded latents

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -42,6 +42,29 @@ To load audio files and related metadata from .tar files in the WebDataset forma
 }
 ```
 
+## Pre Encoded Datasets
+To use pre encoded latents created with the [pre encoding script](pre_encoding.md), set the `dataset_type` property to `"pre_encoded"`, and provide the path to the directory containing the pre encoded `.npy` latent files and corresponding `.json` metadata files.
+
+You can optionally specify `latent_crop_length` to crop the pre encoded latents to a specific length in latent units (latent length = `audio_samples // 2048`). If not specified, uses the full pre encoded length. The `random_crop` option works similarly to other dataset types, randomly cropping from the pre encoded sequence while taking padding into account.
+
+### Example config
+```json
+{
+    "dataset_type": "pre_encoded",
+    "datasets": [
+        {
+            "id": "my_pre_encoded_audio",
+            "path": "/path/to/pre_encoded/output/",
+            "latent_crop_length": 1024,
+            "custom_metadata_module": "/path/to/custom_metadata.py"
+        }
+    ],
+    "random_crop": true
+}
+```
+
+For information on creating pre encoded datasets, see [Pre Encoding](pre_encoding.md).
+
 # Custom metadata
 To customize the metadata provided to the conditioners during model training, you can provide a separate custom metadata module to the dataset config. This metadata module should be a Python file that must contain a function called `get_custom_metadata` that takes in two parameters, `info`, and `audio`, and returns a dictionary. 
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -45,7 +45,9 @@ To load audio files and related metadata from .tar files in the WebDataset forma
 ## Pre Encoded Datasets
 To use pre encoded latents created with the [pre encoding script](pre_encoding.md), set the `dataset_type` property to `"pre_encoded"`, and provide the path to the directory containing the pre encoded `.npy` latent files and corresponding `.json` metadata files.
 
-You can optionally specify `latent_crop_length` to crop the pre encoded latents to a specific length in latent units (latent length = `audio_samples // 2048`). If not specified, uses the full pre encoded length. The `random_crop` option works similarly to other dataset types, randomly cropping from the pre encoded sequence while taking padding into account.
+You can optionally specify a `latent_crop_length` in latent units (latent length = `audio_samples // 2048`) to crop the pre encoded latents to a smaller length than you encoded to. If not specified, uses the full pre encoded length. When `random_crop` is set to true, it will randomly crop from the sequence at your desired `latent_crop_length` while taking padding into account.
+
+**Note**: `random_crop` does not currently update `seconds_start`, so it will be inaccurate when used with models with that condition (e.g. `stable-audio-open-1.0`), but can be used with models that do not use `seconds_start` (e.g. `stable-audio-open-small`).
 
 ### Example config
 ```json
@@ -55,7 +57,7 @@ You can optionally specify `latent_crop_length` to crop the pre encoded latents 
         {
             "id": "my_pre_encoded_audio",
             "path": "/path/to/pre_encoded/output/",
-            "latent_crop_length": 1024,
+            "latent_crop_length": 512,
             "custom_metadata_module": "/path/to/custom_metadata.py"
         }
     ],

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -47,7 +47,7 @@ To use pre encoded latents created with the [pre encoding script](pre_encoding.m
 
 You can optionally specify a `latent_crop_length` in latent units (latent length = `audio_samples // 2048`) to crop the pre encoded latents to a smaller length than you encoded to. If not specified, uses the full pre encoded length. When `random_crop` is set to true, it will randomly crop from the sequence at your desired `latent_crop_length` while taking padding into account.
 
-**Note**: `random_crop` does not currently update `seconds_start`, so it will be inaccurate when used with models with that condition (e.g. `stable-audio-open-1.0`), but can be used with models that do not use `seconds_start` (e.g. `stable-audio-open-small`).
+**Note**: `random_crop` does not currently update `seconds_start`, so it will be inaccurate when used to train or fine-tune models with that condition (e.g. `stable-audio-open-1.0`), but can be used with models that do not use `seconds_start` (e.g. `stable-audio-open-small`).
 
 ### Example config
 ```json

--- a/docs/diffusion.md
+++ b/docs/diffusion.md
@@ -61,6 +61,10 @@ The `training` config in the diffusion model config file should have the followi
     - Optional, overrides `learning_rate`
 - `demo`
     - Configuration for the demos during training, including conditioning information
+- `pre_encoded`
+    - If true, indicates that the model should operate on [pre encoded latents](pre_encoding.md) instead of raw audio
+    - Required when training with [pre encoded datasets](datasets.md#pre-encoded-datasets)
+    - Optional. Default: `false`
 
 ## Example config
 ```json

--- a/docs/pre_encoding.md
+++ b/docs/pre_encoding.md
@@ -6,6 +6,8 @@ When training models on encoded latents from a frozen pre-trained autoencoder, t
 
 To pre-encode audio to latents, you'll need a dataset config file, an autoencoder model config file, and an **unwrapped** autoencoder checkpoint file.
 
+**Note:** You can find a copy of the unwrapped VAE checkpoint (`vae_model.ckpt`) and config (`vae_config.json`) in the `stabilityai/stable-audio-open-1.0` Hugging Face [repo](https://huggingface.co/stabilityai/stable-audio-open-1.0). This is the same VAE used in both `stable-audio-open-1.0` and [`stable-audio-open-small`].
+
 ## Run the Pre Encoding Script
 
 To pre-encode latents from an autoencoder model, you can use `pre_encode.py`. This script will load a pre-trained autoencoder, encode the latents/tokens, and save them to disk in a format that can be easily loaded during training.
@@ -49,6 +51,8 @@ The `pre_encode.py` script accepts the following command line arguments:
 - `--shuffle`
   - If true, shuffles the dataset
   - Optional
+
+**Note:** When pre encoding, it's recommended to set `"drop_last": false` in your dataset config to ensure the last batch is processed even if it's not full.
 
 For example, if you wanted to encode latents with padding up to 30 seconds long in half precision, you could run the following:
 
@@ -106,3 +110,7 @@ In your associated txt2audio model config file, you'll also need to specify `pre
         "pre_encoded": true,
     ...
 ```
+
+**Note:** The autoencoder downsampling ratio is 2048:1, meaning the latent length is `audio_samples // 2048`. It is recommended to ensure your `--sample-size` is divisible by 2048. For reference, SAO Small uses a latent length of 256, while SAO 1.0 uses 1024.
+
+For detailed information on configuring pre encoded datasets, see the [Pre Encoded Datasets](datasets.md#pre-encoded-datasets) section in the datasets documentation.

--- a/docs/pre_encoding.md
+++ b/docs/pre_encoding.md
@@ -6,7 +6,7 @@ When training models on encoded latents from a frozen pre-trained autoencoder, t
 
 To pre-encode audio to latents, you'll need a dataset config file, an autoencoder model config file, and an **unwrapped** autoencoder checkpoint file.
 
-**Note:** You can find a copy of the unwrapped VAE checkpoint (`vae_model.ckpt`) and config (`vae_config.json`) in the `stabilityai/stable-audio-open-1.0` Hugging Face [repo](https://huggingface.co/stabilityai/stable-audio-open-1.0). This is the same VAE used in both `stable-audio-open-1.0` and [`stable-audio-open-small`].
+**Note:** You can find a copy of the unwrapped VAE checkpoint (`vae_model.ckpt`) and config (`vae_config.json`) in the `stabilityai/stable-audio-open-1.0` Hugging Face [repo](https://huggingface.co/stabilityai/stable-audio-open-1.0). This is the same VAE used in  `stable-audio-open-small`.
 
 ## Run the Pre Encoding Script
 
@@ -85,7 +85,7 @@ Inside the numbered subdirectories, you will find the encoded latents as `.npy` 
 
 ## Training on Pre Encoded Latents
 
-Once you have saved your latents to disk, you can use them to train a model by providing a dataset config file to `train.py` that points to the pre-encoded latents, specifying `"dataset_type"` is `"pre_encoded"`. Under the hood, this will configure a `stable_audio_tools.data.dataset.PreEncodedDataset`.
+Once you have saved your latents to disk, you can use them to train a model by providing a dataset config file to `train.py` that points to the pre-encoded latents, specifying `"dataset_type"` is `"pre_encoded"`. Under the hood, this will configure a `stable_audio_tools.data.dataset.PreEncodedDataset`. For more information on configuring pre encoded datasets, see the [Pre Encoded Datasets](datasets.md#pre-encoded-datasets) section of the datasets docs.
 
 The dataset config file should look something like this:
 
@@ -95,22 +95,18 @@ The dataset config file should look something like this:
     "datasets": [
         {
             "id": "my_audio",
-            "path": "/path/to/output/dir",
-            "latent_crop_length": 645
+            "path": "/path/to/output/dir"
         }
     ],
     "random_crop": false
 }
 ```
 
-In your associated txt2audio model config file, you'll also need to specify `pre_encoded: true` in the `training` section to tell the training wrapper to operate on pre encoded latents instead of audio.
+In your diffusion model config, you'll also need to specify `pre_encoded: true` in the [`training` section](diffusion.md#training-configs) to tell the training wrapper to operate on pre encoded latents instead of audio.
 
-```
-    "training": {
-        "pre_encoded": true,
+```json
+"training": {
+    "pre_encoded": true,
     ...
+}
 ```
-
-**Note:** The autoencoder downsampling ratio is 2048:1, meaning the latent length is `audio_samples // 2048`. It is recommended to ensure your `--sample-size` is divisible by 2048. For reference, SAO Small uses a latent length of 256, while SAO 1.0 uses 1024.
-
-For detailed information on configuring pre encoded datasets, see the [Pre Encoded Datasets](datasets.md#pre-encoded-datasets) section in the datasets documentation.

--- a/docs/pre_encoding.md
+++ b/docs/pre_encoding.md
@@ -98,3 +98,11 @@ The dataset config file should look something like this:
     "random_crop": false
 }
 ```
+
+In your associated txt2audio model config file, you'll also need to specify `pre_encoded: true` in the `training` section to tell the training wrapper to operate on pre encoded latents instead of audio.
+
+```
+    "training": {
+        "pre_encoded": true,
+    ...
+```


### PR DESCRIPTION
Adds more verbose information around usage of pre encoded latents/pre encoded dataset that came up on Discord and issue here. Tried not to pollute too much...can cut this down a bit if you think its too noisy @zqevans.

- [x] add note about where to find unwrapped vae checkpoint
- [x] clarify what latent crop length is + that it is optional
- [x] warn about seconds start not being supported by random crop (could alternatively just fix instead?)
- [x] add example config w/o cropping and one w/ cropping
- [x] include pre encoded option in list of diffusion training options (Resolves #210)