### PR TITLE
Update seconds_start based on latent crop in PreEncodedDataset

### DIFF
--- a/stable_audio_tools/data/dataset.py
+++ b/stable_audio_tools/data/dataset.py
@@ -11,6 +11,7 @@ import time
 import torch
 import torchaudio
 import webdataset as wds
+import math
 
 from os import path
 from torch import nn
@@ -325,7 +326,7 @@ class PreEncodedDataset(torch.utils.data.Dataset):
                     info["timestamps"][1] - info["timestamps"][0]
                 )
                 seconds_per_latent = original_length / info["padding_mask"].count(1)
-                info["seconds_start"] += start * seconds_per_latent
+                info["seconds_start"] += math.floor(start * seconds_per_latent)
 
                 latents = latents[:, start : start + self.latent_crop_length]
 


### PR DESCRIPTION
This PR updates `seconds_start` to reflect the random latent crop applied in PreEncodedDataset.
This enables training or fine-tuning models with the `seconds_start` condition when using pre-encoded latents.