### PR TITLE
Fix generate_diffusion_uncond: remove unsupported mask arg in sample_k call

### DIFF
--- a/stable_audio_tools/inference/generation.py
+++ b/stable_audio_tools/inference/generation.py
@@ -75,7 +75,7 @@ def generate_diffusion_uncond(
 
     if diff_objective == "v":    
         # k-diffusion denoising process go!
-        sampled = sample_k(model.model, noise, init_audio, mask, steps, **sampler_kwargs, device=device)
+        sampled = sample_k(model.model, noise, init_audio, steps, **sampler_kwargs, device=device)
     elif diff_objective in ["rectified_flow", "rf_denoiser"]:
         sampled = sample_rf(model.model, noise, init_data=init_audio, steps=steps, **sampler_kwargs, device=device)
 


### PR DESCRIPTION
This PR fixes a runtime error in `generate_diffusion_uncond` caused by passing an unexpected `mask` argument to `sample_k`.

In stable_audio_tools/inference/generation.py, line ~78, the `generate_diffusion_uncond` calls:
```
sampled = sample_k(model.model, noise, init_audio, mask, steps, **sampler_kwargs, device=device)
```
However, `sample_k` (defined in `stable_audio_tools/inference/sampling.py`) expects the 4th positional argument to be `steps` and does not accept a `mask` parameter at all.  Other call sites use `sample_k` without `mask`.