### PR TITLE
Fix operator precedence bug in condition unwrapping

### DIFF
--- a/stable_audio_tools/models/conditioners.py
+++ b/stable_audio_tools/models/conditioners.py
@@ -668,7 +668,7 @@ class MultiConditioner(nn.Module):
                         raise ValueError(f"Conditioner key {condition_key} not found in batch metadata")
 
                 #Unwrap the condition info if it's a single-element list or tuple, this is to support collation functions that wrap everything in a list
-                if isinstance(x[condition_key], list) or isinstance(x[condition_key], tuple) and len(x[condition_key]) == 1:
+                if (isinstance(x[condition_key], list) or isinstance(x[condition_key], tuple)) and len(x[condition_key]) == 1:
                     conditioner_input = x[condition_key][0]
                     
                 else:


### PR DESCRIPTION
## Summary
- Fixes operator precedence bug in `conditioners.py` that caused incorrect condition unwrapping behavior
- Without parentheses, Python evaluates `A or B and C` as `A or (B and C)`, causing lists to always be unwrapped regardless of length

## The Bug
**Before (incorrect):**
```python
if isinstance(x[condition_key], list) or isinstance(x[condition_key], tuple) and len(x[condition_key]) == 1:
```
This unwraps:
- All lists (regardless of length) - **BUG!**
- Single-element tuples only

**After (correct):**
```python
if (isinstance(x[condition_key], list) or isinstance(x[condition_key], tuple)) and len(x[condition_key]) == 1:
```
This correctly unwraps:
- Single-element lists only
- Single-element tuples only

This matches the intent described in the comment: "Unwrap the condition info if it's a single-element list or tuple"

## Test plan
- [ ] Verify that multi-element lists are no longer incorrectly unwrapped
- [ ] Verify single-element lists and tuples are still properly unwrapped

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)