### PR TITLE
Fix uv install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ We use [uv](https://docs.astral.sh/uv/) for fast, reproducible dependency manage
 
 Clone the repo and install dependencies:
 ```bash
-$ git clone https://github.com/Stability-AI/stable-audio-tools-dev.git
-$ cd stable-audio-tools-dev
+$ git clone https://github.com/Stability-AI/stable-audio-tools.git
+$ cd stable-audio-tools
 
 # Inference only
 $ uv sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ ui = [
     "gradio==6.3.0",
 ]
 all = [
-    "stable-audio-tools-dev[train,ui]",
+    "stable-audio-tools[train,ui]",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -2119,8 +2119,8 @@ wheels = [
 ]
 
 [[package]]
-name = "stable-audio-tools-dev"
-version = "0.0.10"
+name = "stable-audio-tools"
+version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "alias-free-torch" },
@@ -2203,7 +2203,7 @@ requires-dist = [
     { name = "sentencepiece", specifier = "==0.1.99" },
     { name = "setuptools", specifier = "<81" },
     { name = "soxr" },
-    { name = "stable-audio-tools-dev", extras = ["train", "ui"], marker = "extra == 'all'" },
+    { name = "stable-audio-tools", extras = ["train", "ui"], marker = "extra == 'all'" },
     { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'", specifier = "==2.7.1" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==2.7.1", index = "https://download.pytorch.org/whl/cu126" },
     { name = "torchaudio", marker = "platform_machine != 'x86_64' or sys_platform != 'linux'", specifier = "==2.7.1" },


### PR DESCRIPTION
Appears there was an internal repo in the README's instructions/pyproject/uv lock files. This broke the `uv sync` install when I went to try it. Updating to public repo's name here fixes the issue.