### PR TITLE
fix: enter autocast context manager in T5/text conditioner

### DIFF
--- a/stable_audio_tools/models/conditioners.py
+++ b/stable_audio_tools/models/conditioners.py
@@ -524,7 +524,7 @@ class T5Conditioner(Conditioner):
 
         self.model.eval()
 
-        with torch.amp.autocast('cuda', dtype=torch.float16) and torch.set_grad_enabled(self.enable_grad):
+        with torch.amp.autocast('cuda', dtype=torch.float16), torch.set_grad_enabled(self.enable_grad):
             embeddings = self.model(
                 input_ids=input_ids, attention_mask=attention_mask
             )["last_hidden_state"]


### PR DESCRIPTION
Fixes #238

## Problem

In `stable_audio_tools/models/conditioners.py`:

```python
with torch.amp.autocast('cuda', dtype=torch.float16) and torch.set_grad_enabled(self.enable_grad):
```

Python evaluates the `and` expression **before** the `with` binds anything. `torch.amp.autocast(...)` returns a truthy object, so `A and B` short-circuits to its right operand, `torch.set_grad_enabled(...)`. The `with` statement therefore enters **only** `set_grad_enabled` — `autocast.__enter__()` is never called, so fp16 autocast is silently inactive for this conditioner's forward pass (it runs in the ambient dtype instead of float16).

## Fix

Separate the two context managers with a comma so both are entered, which is the intended behaviour:

```python
with torch.amp.autocast('cuda', dtype=torch.float16), torch.set_grad_enabled(self.enable_grad):
```

One-token change, verifiable by inspection — this is the classic `with A and B:` context-manager pitfall. It's the only occurrence of the pattern in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)