### PR TITLE
fix: avoid int32 overflow in random seed generation

### DIFF
--- a/stable_audio_tools/inference/generation.py
+++ b/stable_audio_tools/inference/generation.py
@@ -195,7 +195,7 @@ def generate_diffusion_cond(
         
     # Seed
     # The user can explicitly set the seed to deterministically generate the same output. Otherwise, use a random seed.
-    seed = seed if seed != -1 else np.random.randint(0, 2**32 - 1)
+    seed = seed if seed != -1 else np.random.randint(0, 2**32 - 1, dtype=np.uint32)
     torch.manual_seed(seed)
     # Define the initial noise immediately after setting the seed
     noise = torch.randn([batch_size, model.io_channels, latent_sample_size], device=device)
@@ -465,7 +465,7 @@ def generate_diffusion_cond_inpaint(
 
     # Seed
     # The user can explicitly set the seed to deterministically generate the same output. Otherwise, use a random seed.
-    seed = seed if seed != -1 else np.random.randint(0, 2**32 - 1)
+    seed = seed if seed != -1 else np.random.randint(0, 2**32 - 1, dtype=np.uint32)
     torch.manual_seed(seed)
     # Define the initial noise immediately after setting the seed
     noise = torch.randn([batch_size, model.io_channels, sample_size], device=device)


### PR DESCRIPTION
Fixes #195

## Problem

Three call sites generate a random seed with:

```python
seed = seed if seed != -1 else np.random.randint(0, 2**32 - 1)
```

`np.random.randint` uses numpy's default integer dtype, which is **int32 on some platforms (notably Windows)**. The high bound `2**32 - 1` exceeds int32's max (`2**31 - 1`), so numpy raises:

```
ValueError: high is out of bounds for int32
```

on every auto-seed (`seed == -1`) generation.

## Fix

Line 36 already handles this correctly with `dtype=np.uint32`. This applies the maintainers' own fix to the two remaining occurrences (lines 198 and 468), so all three seed sites are consistent.

Verifiable by inspection — mirrors the existing fix on line 36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)